### PR TITLE
add A_phi constraint and new test for A_phi constraint

### DIFF
--- a/SOSAT/__init__.py
+++ b/SOSAT/__init__.py
@@ -15,6 +15,7 @@ __version__ = '0.3.1'
 from .stress_state import StressState, units
 from .constraints import FaultConstraint
 from .constraints import FaultingRegimeConstraint, SU
+from .constraints import FaultingRegimeAphiConstraint
 from .constraints import BreakoutConstraint
 from .constraints import DITFConstraint
 from .constraints import StressMeasurement

--- a/SOSAT/constraints/__init__.py
+++ b/SOSAT/constraints/__init__.py
@@ -1,5 +1,6 @@
 from .fault_constraint import FaultConstraint
 from .faulting_regime_constraint import FaultingRegimeConstraint, SU
+from .faulting_regime_A_phi_constraint import FaultingRegimeAphiConstraint
 from .breakout_constraint import BreakoutConstraint
 from .DITF_constraint import DITFConstraint
 from .stress_measurement_constraint import StressMeasurement

--- a/SOSAT/constraints/faulting_regime_A_phi_constraint.py
+++ b/SOSAT/constraints/faulting_regime_A_phi_constraint.py
@@ -1,0 +1,40 @@
+import numpy as np
+import numpy.ma as ma
+from .constraint_base import StressConstraint
+
+
+class FaultingRegimeAphiConstraint(StressConstraint):
+    """
+    A class that constrains the state of stress based on knowledge or
+    assumptions about the probability of A_phi values.
+
+    Parameters
+    ----------
+    A_phi_dist :  subclass of `scipy.stats.rv_continuous`
+        The probability density function for the scalar A_phi value.
+        See `StressState.A_phi_calculate` for details on the
+        definition of the scalar regime parameter A_phi.
+        Any subclass of `scipy.stats.rv_continuous`
+        defined from 0 to 3 can be used.
+        For example, the truncated normal distribution is used.
+        from scipy.stats import truncnorm
+        lower_bound = 0 (fixed)
+        upper_bound = 3 (fixed)
+        mean = 0.5 (changeable, mean of A_phi value at this region)
+        variance = 0.08 (changable, variance of A_phi value at this region)
+        std = np.sqrt(variance)
+        rv = truncnorm((lower_bound-mean)/std, \
+                       (upper_bound-mean)/std, mean, std)
+    """
+
+    def __init__(self, A_phi_dist):
+        """
+        Constructor method
+        """
+        self._A_phi_dist = A_phi_dist
+
+    def loglikelihood(self, ss):
+        A_phi = ss.A_phi_calculate()
+        with np.errstate(divide='ignore'):
+            loglikelihood = np.log(self._A_phi_dist.pdf(A_phi))
+        return loglikelihood

--- a/SOSAT/stress_state.py
+++ b/SOSAT/stress_state.py
@@ -237,6 +237,63 @@ class StressState:
         ret.mask = self.shmin_grid.mask
         return ret
 
+    def A_phi_calculate(self):
+        """
+        Computes the scalar A_phi value for each stress state
+        included in the class. The scalar regime parameter varies from
+        0 to 1.
+        The scalar measure of the faulting regime is defined
+        in Simpson (1997):
+
+            phi = (sigma2-sigma3)/ (sigma1-sigma3)
+            n = 0, 1, and 2 respectively for normal, strike-slip,
+            and reverse faulting regime respectively.
+            A_phi = (n+0.5) + (-1)^n*(phi-0.5)
+
+        Using this definition, A_phi value ranges from 0 to 3, where
+        [0,1] corresponds to normal faulting regime,
+        [1,2] corresponds to strike-slip faulting regime,  and
+        [2,3] corresponds to reverse faulting regime.
+
+        Returns
+        -------
+        2D Numpy MaskedArray with dtype=float
+            The array is square with dimensions :attr:`nbins`
+
+        """
+
+        # initiate empty value store
+        Sv_grid = self.vertical_stress*np.ones_like(self.shmax_grid)
+        A_phi_grid = np.zeros_like(self.shmax_grid)
+        sigma1 = np.zeros_like(self.shmax_grid)
+        sigma2 = np.zeros_like(self.shmax_grid)
+        sigma3 = np.zeros_like(self.shmax_grid)
+
+        # Get three principal stresses
+        NFindex = self.vertical_stress > self.shmax_grid
+        TFindex = self.shmin_grid > self.vertical_stress
+        SSindex = ~NFindex & ~TFindex
+        sigma1[NFindex] = Sv_grid[NFindex]
+        sigma1[SSindex] = self.shmax_grid[SSindex]
+        sigma1[TFindex] = self.shmax_grid[TFindex]
+        sigma3[NFindex] = self.shmin_grid[NFindex]
+        sigma3[SSindex] = self.shmin_grid[SSindex]
+        sigma3[TFindex] = Sv_grid[TFindex]
+        sigma2[NFindex] = self.shmax_grid[NFindex]
+        sigma2[SSindex] = Sv_grid[SSindex]
+        sigma2[TFindex] = self.shmin_grid[TFindex]
+
+        # calculate A_phi
+        phi = (sigma2-sigma3)/(sigma1-sigma3)
+        n_NF = 0
+        n_SS = 1
+        n_TF = 2
+        A_phi_grid[NFindex] = (n_NF+0.5)+(-1)**n_NF*(phi[NFindex]-0.5)
+        A_phi_grid[SSindex] = (n_SS+0.5)+(-1)**n_SS*(phi[SSindex]-0.5)
+        A_phi_grid[TFindex] = (n_TF+0.5)+(-1)**n_TF*(phi[TFindex]-0.5)
+
+        return A_phi_grid
+
     def add_constraint(self, constraint):
         """
         Method to add a constraint to the stress state probability

--- a/SOSAT/stress_state.py
+++ b/SOSAT/stress_state.py
@@ -263,7 +263,7 @@ class StressState:
         """
 
         # initiate empty value store
-        Sv_grid = self.vertical_stress*np.ones_like(self.shmax_grid)
+        Sv_grid = self.vertical_stress * np.ones_like(self.shmax_grid)
         A_phi_grid = np.zeros_like(self.shmax_grid)
         sigma1 = np.zeros_like(self.shmax_grid)
         sigma2 = np.zeros_like(self.shmax_grid)
@@ -284,13 +284,13 @@ class StressState:
         sigma2[TFindex] = self.shmin_grid[TFindex]
 
         # calculate A_phi
-        phi = (sigma2-sigma3)/(sigma1-sigma3)
+        phi = (sigma2 - sigma3) / (sigma1 - sigma3)
         n_NF = 0
         n_SS = 1
         n_TF = 2
-        A_phi_grid[NFindex] = (n_NF+0.5)+(-1)**n_NF*(phi[NFindex]-0.5)
-        A_phi_grid[SSindex] = (n_SS+0.5)+(-1)**n_SS*(phi[SSindex]-0.5)
-        A_phi_grid[TFindex] = (n_TF+0.5)+(-1)**n_TF*(phi[TFindex]-0.5)
+        A_phi_grid[NFindex] = (n_NF + 0.5) + (-1)**n_NF * (phi[NFindex] - 0.5)
+        A_phi_grid[SSindex] = (n_SS + 0.5) + (-1)**n_SS * (phi[SSindex] - 0.5)
+        A_phi_grid[TFindex] = (n_TF + 0.5) + (-1)**n_TF * (phi[TFindex] - 0.5)
 
         return A_phi_grid
 

--- a/tests/constraints/test_A_phi_constraint.py
+++ b/tests/constraints/test_A_phi_constraint.py
@@ -1,0 +1,57 @@
+import pytest
+from scipy.stats import truncnorm
+import numpy as np
+import matplotlib.pyplot as plt
+from numpy import unravel_index
+from SOSAT import StressState
+from SOSAT.constraints import FaultingRegimeAphiConstraint
+
+
+def test_A_phi():
+    # depth in meters
+    depth = 1228.3
+    # density in kg/m^3
+    avg_overburden_density = 2580.0
+    # pore pressure gradient in MPa/km
+    pore_pressure_grad = 9.955
+
+    pore_pressure = pore_pressure_grad * (1.0 / 1000) * depth
+
+    ss = StressState(depth=depth,
+                     avg_overburden_density=avg_overburden_density,
+                     pore_pressure=pore_pressure)
+
+    # add faulting regime Aphi constraint
+    lower_bound = 0
+    upper_bound = 3
+    mean = 1.5  # (changeable, mean of A_phi value at this region)
+    variance = 0.08  # (changable, variance of A_phi value at this region)
+    std = np.sqrt(variance)
+    rv = truncnorm((lower_bound - mean) / std, (upper_bound - mean) / std,
+                   mean, std)
+    # check random variable: plot pdf and cdf of the defined random variable
+    x = np.linspace(0, 3, 50)
+    fig, ax = plt.subplots(1, 2, figsize=(10, 5))
+    fig.suptitle(f'Mean is {mean:.2f}; Std is {std:.2f}')
+    ax[0].plot(x, rv.pdf(x), 'k-', lw=2)
+    ax[0].set_xlabel(r'$A_{\phi}$')
+    ax[0].set_ylabel('pdf')
+    ax[1].plot(x, rv.cdf(x), 'k-', lw=2)
+    ax[1].set_xlabel(r'$A_{\phi}$')
+    ax[1].set_ylabel('cdf')
+
+    frAc = FaultingRegimeAphiConstraint(rv)
+
+    ss.add_constraint(frAc)
+
+    fig2 = ss.plot_posterior()
+    fig2.savefig("fault_regime_constraint_posterior.png")
+
+    # perform test
+    max_post_index = unravel_index(ss.posterior.argmax(), ss.posterior.shape)
+    max_Aphi = ss.A_phi_calculate()[max_post_index[0], max_post_index[1]]
+    max_Aphi == pytest.approx(mean)
+
+
+if __name__ == 'main':
+    test_A_phi()


### PR DESCRIPTION
A_phi constraint is added. 

A new test for A_phi is added. A_phi takes the distribution of the truncated normal distribution. 
The test is set that: 
With only A_phi constraint applied, the location where it has the maximum stress posterior is the location where we have the A_phi_mean. 