### PR TITLE
Separate the GenerateSamples out of the EvaluateFail

### DIFF
--- a/tests/risk_analysis/test_critical_fault_activation_risk.py
+++ b/tests/risk_analysis/test_critical_fault_activation_risk.py
@@ -31,7 +31,9 @@ def test_cfa():
     dPmax = 4.0
     gamma_dist = uniform(0.4, (0.6 - 0.4))
     cfa = CriticalFaultActivation(ss, dPmax, gamma_dist)
-    pressures, Pfail = cfa.EvaluatePfail()
+    shmin, shmax, sv = cfa.SampleStressPoints()
+    pressures, Pfail = cfa.EvaluatePfail(
+        shmin=shmin, shmax=shmax, sv=sv)
     print("pressures= ", pressures)
     print("Pfail= ", Pfail)
     pressures[0] == pytest.approx(12.227)

--- a/tests/risk_analysis/test_hydraulic_fracturing_risk.py
+++ b/tests/risk_analysis/test_hydraulic_fracturing_risk.py
@@ -30,8 +30,9 @@ def test_hf():
     T_dist = uniform(0.0, 5.0)
 
     hf = HydraulicFracturing(ss, dPmax, gamma_dist)
-
-    pressures, Pfail = hf.EvaluatePfail()
+    shmin, shmax, sv = hf.SampleStressPoints(Nsamples=1e5)
+    pressures, Pfail = hf.EvaluatePfail(
+        shmin=shmin, shmax=shmax, sv=sv)
 
     print("pressures= ", pressures)
     print("Pfail= ", Pfail)


### PR DESCRIPTION
Separate the GenerateSamples out of the EvaluateFail so that stress samples do not need to be generated again each time we call EvaluateFail. EvaluateFail could read in shmin, shmax, sv that can be calculated using self.SampleStressPoints().