### PR TITLE
Plot posterior fix

### DIFF
--- a/SOSAT/stress_state.py
+++ b/SOSAT/stress_state.py
@@ -393,8 +393,8 @@ class StressState:
             self.evaluate_posterior()
 
         # Convert data format to bin-centered eval of PDF for plotting
-        dsig = self.shmax_grid[0][1]-self.shmax_grid[0][0]
-        posterior_PDF = self.posterior/dsig**2.0
+        dsig = self.shmax_grid[0][1] - self.shmax_grid[0][0]
+        posterior_PDF = self.posterior / dsig**2.0
 
         fig = plt.figure(figsize=(figwidth, figheight))
         ax = fig.add_subplot(111)

--- a/SOSAT/stress_state.py
+++ b/SOSAT/stress_state.py
@@ -392,11 +392,15 @@ class StressState:
         if not self._posterior_evaluated:
             self.evaluate_posterior()
 
+        # Convert data format to bin-centered eval of PDF for plotting
+        dsig = self.shmax_grid[0][1]-self.shmax_grid[0][0]
+        posterior_PDF = self.posterior/dsig**2.0
+
         fig = plt.figure(figsize=(figwidth, figheight))
         ax = fig.add_subplot(111)
         im = ax.contourf(self.shmin_grid,
                          self.shmax_grid,
-                         self.posterior,
+                         posterior_PDF,
                          contour_levels,
                          cmap=plt.cm.Greys)
         plt.colorbar(im, format=ticker.FuncFormatter(fmt))

--- a/tests/test_PDF_plotting.py
+++ b/tests/test_PDF_plotting.py
@@ -8,49 +8,49 @@ from SOSAT.constraints import FaultConstraint
 
 def test_PDF_plotting():
 
-	# depth in meters
-	depth = 1228.3
-	# density in kg/m^3
-	avg_overburden_density = 2580.0
-	# pore pressure gradient in MPa/km
-	pore_pressure_grad = 9.955
+    # depth in meters
+    depth = 1228.3
+    # density in kg/m^3
+    avg_overburden_density = 2580.0
+    # pore pressure gradient in MPa/km
+    pore_pressure_grad = 9.955
 
-	pore_pressure = pore_pressure_grad * (1.0 / 1000) * depth
+    pore_pressure = pore_pressure_grad * (1.0 / 1000) * depth
 
-	# Create two StessState objects that differ only for nbins
-	ss_50 = StressState(depth=depth,
-	                avg_overburden_density=avg_overburden_density,
-	                pore_pressure=pore_pressure,nbins=50)
+    # Create two StessState objects that differ only for nbins
+    ss_50 = StressState(depth=depth,
+                        avg_overburden_density=avg_overburden_density,
+                        pore_pressure=pore_pressure, nbins=50)
 
-	ss_5000 = StressState(depth=depth,
-	                avg_overburden_density=avg_overburden_density,
-	                pore_pressure=pore_pressure,nbins=5000)
+    ss_5000 = StressState(depth=depth,
+                          avg_overburden_density=avg_overburden_density,
+                          pore_pressure=pore_pressure, nbins=5000)
 
-	fc = FaultConstraint()
+    fc = FaultConstraint()
 
-	ss_50.add_constraint(fc)
-	ss_5000.add_constraint(fc)
+    ss_50.add_constraint(fc)
+    ss_5000.add_constraint(fc)
 
-	ss_50.evaluate_posterior()
-	ss_5000.evaluate_posterior()
+    ss_50.evaluate_posterior()
+    ss_5000.evaluate_posterior()
 
-	# These lines are repeated in StressState.plot_posterior()
-	# Convert data format to bin-centered eval of PDF for plotting
-	dsig_50 = ss_50.shmax_grid[0][1]-ss_50.shmax_grid[0][0]
-	posterior_PDF_50 = ss_50.posterior/dsig_50**2.0
+    # These lines are repeated in StressState.plot_posterior()
+    # Convert data format to bin-centered eval of PDF for plotting
+    dsig_50 = ss_50.shmax_grid[0][1] - ss_50.shmax_grid[0][0]
+    posterior_PDF_50 = ss_50.posterior / dsig_50**2.0
 
-	dsig_5000 = ss_5000.shmax_grid[0][1]-ss_5000.shmax_grid[0][0]
-	posterior_PDF_5000 = ss_5000.posterior/dsig_5000**2.0
+    dsig_5000 = ss_5000.shmax_grid[0][1] - ss_5000.shmax_grid[0][0]
+    posterior_PDF_5000 = ss_5000.posterior / dsig_5000**2.0
 
-	# Test if maximum value of posterior is approximately equal
-	# Small err is expected due to different discretizations of sigma-space
-	tol = 5.0e-2
-	rel_err = (np.nanmax(posterior_PDF_50) - np.nanmax(posterior_PDF_5000)) \
-		/ np.nanmax(posterior_PDF_50)
-	assert rel_err <= tol
+    # Test if maximum value of posterior is approximately equal
+    # Small err is expected due to different discretizations of sigma-space
+    tol = 5.0e-2
+    rel_err = (np.nanmax(posterior_PDF_50) - np.nanmax(posterior_PDF_5000)) \
+        / np.nanmax(posterior_PDF_50)
+    assert rel_err <= tol
 
-	fig_50 = ss_50.plot_posterior()
-	fig_5000 = ss_5000.plot_posterior()
+    fig_50 = ss_50.plot_posterior()
+    fig_5000 = ss_5000.plot_posterior()
 
-	fig_50.savefig("50_bin_posterior_PDF.png")
-	fig_5000.savefig("5000_bin_posterior_PDF.png")
+    fig_50.savefig("50_bin_posterior_PDF.png")
+    fig_5000.savefig("5000_bin_posterior_PDF.png")

--- a/tests/test_PDF_plotting.py
+++ b/tests/test_PDF_plotting.py
@@ -1,0 +1,56 @@
+import pytest
+import numpy as np
+import matplotlib.pyplot as plt
+
+from SOSAT import StressState
+from SOSAT.constraints import FaultConstraint
+
+
+def test_PDF_plotting():
+
+	# depth in meters
+	depth = 1228.3
+	# density in kg/m^3
+	avg_overburden_density = 2580.0
+	# pore pressure gradient in MPa/km
+	pore_pressure_grad = 9.955
+
+	pore_pressure = pore_pressure_grad * (1.0 / 1000) * depth
+
+	# Create two StessState objects that differ only for nbins
+	ss_50 = StressState(depth=depth,
+	                avg_overburden_density=avg_overburden_density,
+	                pore_pressure=pore_pressure,nbins=50)
+
+	ss_5000 = StressState(depth=depth,
+	                avg_overburden_density=avg_overburden_density,
+	                pore_pressure=pore_pressure,nbins=5000)
+
+	fc = FaultConstraint()
+
+	ss_50.add_constraint(fc)
+	ss_5000.add_constraint(fc)
+
+	ss_50.evaluate_posterior()
+	ss_5000.evaluate_posterior()
+
+	# These lines are repeated in StressState.plot_posterior()
+	# Convert data format to bin-centered eval of PDF for plotting
+	dsig_50 = ss_50.shmax_grid[0][1]-ss_50.shmax_grid[0][0]
+	posterior_PDF_50 = ss_50.posterior/dsig_50**2.0
+
+	dsig_5000 = ss_5000.shmax_grid[0][1]-ss_5000.shmax_grid[0][0]
+	posterior_PDF_5000 = ss_5000.posterior/dsig_5000**2.0
+
+	# Test if maximum value of posterior is approximately equal
+	# Small err is expected due to different discretizations of sigma-space
+	tol = 5.0e-2
+	rel_err = (np.nanmax(posterior_PDF_50) - np.nanmax(posterior_PDF_5000)) \
+		/ np.nanmax(posterior_PDF_50)
+	assert rel_err <= tol
+
+	fig_50 = ss_50.plot_posterior()
+	fig_5000 = ss_5000.plot_posterior()
+
+	fig_50.savefig("50_bin_posterior_PDF.png")
+	fig_5000.savefig("5000_bin_posterior_PDF.png")


### PR DESCRIPTION
This branch includes a temporary fix to the plot_posterior() method such that the plot now shows the bin-centered evaluation of the PDF. Branch also includes an integration test for the new plotting function. 